### PR TITLE
Feature/wpp 003 add card screen

### DIFF
--- a/lib/app/modules/home/presentation/controllers/home_page_controller.dart
+++ b/lib/app/modules/home/presentation/controllers/home_page_controller.dart
@@ -25,13 +25,7 @@ class HomePageController extends PageLifeCycleController {
       store.loading();
       store.weatherData = await fetchCityWeatherUseCase.call(citiesForms: store.cities);
       for (WeatherEntity weather in store.weatherData) {
-        final card = CityCard(
-          cityName: weather.city!.name,
-          countryName: weather.city!.country,
-          currentTemperature: weather.currentTemperature,
-          currentWeatherCondition: weather.currentWeatherCondition,
-          dailyForecast: weather.dailyForecast!,
-        );
+        final card = CityCard(weather: weather);
         store.cityCards.add(card);
       }
       store.completed();

--- a/lib/app/modules/home/presentation/pages/card_page.dart
+++ b/lib/app/modules/home/presentation/pages/card_page.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:weather_app/app/core/utils/helpers.dart';
+import 'package:weather_app/app/modules/home/domain/entities/daily_forecast_entity.dart';
+import 'package:weather_app/app/modules/home/domain/entities/weather_entity.dart';
+import 'package:weather_app/app/modules/home/presentation/widgets/next_day_box.dart';
+
+class CardPage extends StatelessWidget {
+  const CardPage({
+    super.key,
+    required this.weather,
+  });
+
+  final WeatherEntity weather;
+
+  @override
+  Widget build(BuildContext context) {
+    final List<DailyForecastEntity> firstFiveDaysForecast =
+        weather.dailyForecast!.length > 5 ? weather.dailyForecast!.sublist(0, 5) : weather.dailyForecast!;
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: Text(weather.city!.name),
+      ),
+      body: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('City name: '),
+              Text('${weather.city!.name}, ${weather.city!.country}'),
+            ],
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('Current temperature: '),
+              Text('${weather.currentTemperature}°C'),
+            ],
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('Current weather: '),
+              Text(weather.currentWeatherCondition),
+            ],
+          ),
+          Column(
+            children: [
+              const Text('Next 5 days condition: '),
+              SizedBox(
+                height: 60,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: firstFiveDaysForecast.map((forecast) {
+                    return NextDayBox(
+                      day: formatDate(forecast.date),
+                      temperature: '${forecast.temperature}°C',
+                      weatherCondition: forecast.weatherCondition,
+                    );
+                  }).toList(),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/modules/home/presentation/widgets/city_card.dart
+++ b/lib/app/modules/home/presentation/widgets/city_card.dart
@@ -1,78 +1,79 @@
 import 'package:flutter/material.dart';
 import 'package:weather_app/app/core/core.dart';
+import 'package:weather_app/app/modules/home/domain/entities/weather_entity.dart';
 import 'package:weather_app/app/modules/home/home.dart';
+import 'package:weather_app/app/modules/home/presentation/pages/card_page.dart';
 
 class CityCard extends StatelessWidget {
   const CityCard({
     super.key,
-    required this.cityName,
-    required this.countryName,
-    required this.currentTemperature,
-    required this.currentWeatherCondition,
-    required this.dailyForecast,
+    required this.weather,
   });
 
-  final String cityName;
-  final String countryName;
-  final double currentTemperature;
-  final String currentWeatherCondition;
-  final List<DailyForecastEntity> dailyForecast;
+  final WeatherEntity weather;
 
   @override
   Widget build(BuildContext context) {
     final List<DailyForecastEntity> firstFiveDaysForecast =
-        dailyForecast.length > 5 ? dailyForecast.sublist(0, 5) : dailyForecast;
+        weather.dailyForecast!.length > 5 ? weather.dailyForecast!.sublist(0, 5) : weather.dailyForecast!;
 
-    return Container(
-      decoration: BoxDecoration(
-        color: Colors.blue[200],
-        borderRadius: BorderRadius.circular(8),
+    return InkWell(
+      onTap: () => Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => CardPage(weather: weather),
+        ),
       ),
-      padding: const EdgeInsets.all(8),
-      width: double.infinity,
-      height: 160,
-      child: Column(
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              const Text('City name: '),
-              Text('$cityName, $countryName'),
-            ],
-          ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              const Text('Current temperature: '),
-              Text('$currentTemperature°C'),
-            ],
-          ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              const Text('Current weather: '),
-              Text(currentWeatherCondition),
-            ],
-          ),
-          Column(
-            children: [
-              const Text('Next 5 days condition: '),
-              SizedBox(
-                height: 60,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: firstFiveDaysForecast.map((forecast) {
-                    return NextDayBox(
-                      day: formatDate(forecast.date),
-                      temperature: '${forecast.temperature}°C',
-                      weatherCondition: forecast.weatherCondition,
-                    );
-                  }).toList(),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.blue[200],
+          borderRadius: BorderRadius.circular(8),
+        ),
+        padding: const EdgeInsets.all(8),
+        width: double.infinity,
+        height: 160,
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('City name: '),
+                Text('${weather.city!.name}, ${weather.city!.country}'),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('Current temperature: '),
+                Text('${weather.currentTemperature}°C'),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('Current weather: '),
+                Text(weather.currentWeatherCondition),
+              ],
+            ),
+            Column(
+              children: [
+                const Text('Next 5 days condition: '),
+                SizedBox(
+                  height: 60,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: firstFiveDaysForecast.map((forecast) {
+                      return NextDayBox(
+                        day: formatDate(forecast.date),
+                        temperature: '${forecast.temperature}°C',
+                        weatherCondition: forecast.weatherCondition,
+                      );
+                    }).toList(),
+                  ),
                 ),
-              ),
-            ],
-          ),
-        ],
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Refactor the way weather is passed to the CityCard widget, adds a second page to display information on a cleaner screen and implements navigation.